### PR TITLE
gl-dotnet-email changes for Cc, Bcc, ReplyTo, and attachments

### DIFF
--- a/samples/GeekLearning.Email.Samples/Controllers/HomeController.cs
+++ b/samples/GeekLearning.Email.Samples/Controllers/HomeController.cs
@@ -22,19 +22,37 @@ namespace GeekLearning.Email.Samples.Controllers
 
         public async Task<IActionResult> SendEmail()
         {
-            var user = new User
-            {
-                Email = "john@doe.me",
-                DisplayName = "John Doe"
+            // Email addresses have Email, DisplayName, and an enum: AddressTarget (To,Cc,Bcc, or ReplyTo)
+            List<IEmailAddress> recipients = new List<IEmailAddress>() {
+                new EmailAddress() { Email = "myfriend@aways.com", DisplayName = "Samuel", AddressAs = AddressTarget.To },
+                new EmailAddress() { Email = "rhsmith@gworld.com", DisplayName = "Bob", AddressAs = AddressTarget.Cc },
+                new EmailAddress() { Email = "igetit@world.gov", DisplayName="George Jones", AddressAs= AddressTarget.ReplyTo }
             };
 
+
+            // example of how to add a simple attachment. Add images, streams, etc as byte arrays, for example:
+
+            MimeKit.AttachmentCollection attachments = new MimeKit.AttachmentCollection
+            {
+                { "sample_attachment.txt", System.Text.Encoding.UTF8.GetBytes("This is the content of the file attachment.") }
+            };
+
+            // the Reply-To addresses are simply another list of IEmailAddress objects, here, were are ignoring them as null.
+            // Also, in the From address, the AddressAs property is ignored, and the From address is positional and always treated as the From.
+            // Likewise, a From enumeration value in the recipients list is ignored, and will be treated as a To address.
+            await this.emailSender.SendEmailAsync(new EmailAddress() { Email="to.somebody@domain.tld", DisplayName="Me", AddressAs=AddressTarget.From }, "A simple message","This is a test message", recipients, attachments);
+
+
+            // Here is a second send example. No attachments, but using templates:
+
+            recipients.Clear();
+            recipients.Add(new EmailAddress { Email="george@alaska.edu", DisplayName="George Jones", AddressAs=AddressTarget.To });
             var context = new
             {
                 ApplicationName = "Email Sender Sample",
-                User = user
+                User = recipients
             };
-
-            await this.emailSender.SendTemplatedEmailAsync("Invitation", context, user);
+            await this.emailSender.SendTemplatedEmailAsync("Invitation", context, recipients );
 
             return RedirectToAction("Index");
         }

--- a/src/GeekLearning.Email.InMemory/InMemoryEmailProvider.cs
+++ b/src/GeekLearning.Email.InMemory/InMemoryEmailProvider.cs
@@ -12,8 +12,14 @@
         {
             this.inMemoryEmailRepository = inMemoryEmailRepository;
         }
-
+        
+        // for compatibility: 
         public Task SendEmailAsync(IEmailAddress from, IEnumerable<IEmailAddress> recipients, string subject, string text, string html)
+        {
+            return this.SendEmailAsync(from, recipients, subject, text, html, null);
+        }
+
+        public Task SendEmailAsync(IEmailAddress from, IEnumerable<IEmailAddress> recipients, string subject, string text, string html, MimeKit.AttachmentCollection attachments)
         {
             this.inMemoryEmailRepository.Save(new InMemoryEmail
             {

--- a/src/GeekLearning.Email.SendGrid/SendGridEmailProvider.cs
+++ b/src/GeekLearning.Email.SendGrid/SendGridEmailProvider.cs
@@ -28,7 +28,8 @@
             IEnumerable<IEmailAddress> recipients,
             string subject,
             string text,
-            string html)
+            string html,
+            MimeKit.AttachmentCollection attachments)
         {
 
             var client = new SendGridClient(this.apiKey);

--- a/src/GeekLearning.Email.Smtp/SmtpEmailProvider.cs
+++ b/src/GeekLearning.Email.Smtp/SmtpEmailProvider.cs
@@ -37,13 +37,29 @@
             IEnumerable<IEmailAddress> recipients,
             string subject,
             string text,
-            string html)
+            string html,
+            AttachmentCollection attachments)
         {
             var message = new MimeMessage();
             message.From.Add(new MailboxAddress(from.DisplayName, from.Email));
             foreach (var recipient in recipients)
             {
-                message.To.Add(new MailboxAddress(recipient.DisplayName, recipient.Email));
+                InternetAddress address = new MailboxAddress(recipient.DisplayName, recipient.Email);
+                switch (recipient.AddressAs)
+                {
+                    case AddressTarget.Cc:
+                        message.Cc.Add(address);
+                        break;
+                    case AddressTarget.Bcc:
+                        message.Bcc.Add(address);
+                        break;
+                    case AddressTarget.ReplyTo:
+                        message.ReplyTo.Add(address);
+                        break;
+                    default:
+                        message.To.Add(address);
+                        break;
+                }
             }
 
             message.Subject = subject;
@@ -53,6 +69,15 @@
                 TextBody = text,
                 HtmlBody = html
             };
+            
+            builder.Attachments.Clear();
+            if (attachments != null)
+            {
+                foreach (var attachment in attachments)
+                {
+                    builder.Attachments.Add(attachment);
+                }
+            }
 
             message.Body = builder.ToMessageBody();
 

--- a/src/GeekLearning.Email/IEmailAddress.cs
+++ b/src/GeekLearning.Email/IEmailAddress.cs
@@ -1,9 +1,13 @@
-﻿namespace GeekLearning.Email
+namespace GeekLearning.Email
 {
+    public enum AddressTarget {  From, To, Cc, Bcc, ReplyTo}
+    
     public interface IEmailAddress
     {
         string Email { get; }
 
         string DisplayName { get; }
+        
+        AddressTarget AddressAs { get;  } 
     }
 }

--- a/src/GeekLearning.Email/IEmailProvider.cs
+++ b/src/GeekLearning.Email/IEmailProvider.cs
@@ -1,11 +1,18 @@
-﻿namespace GeekLearning.Email
+namespace GeekLearning.Email
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-
+    using MimeKit;
+    
     public interface IEmailProvider
     {
-        Task SendEmailAsync(IEmailAddress from, IEnumerable<IEmailAddress> recipients, string subject, string bodyText, string bodyHtml);
+        Task SendEmailAsync(
+            IEmailAddress from,
+            IEnumerable<IEmailAddress> recipients,
+            string subject, 
+            string bodyText, 
+            string bodyHtml
+            AttachmentCollection attachments=null);
     }
 }
 

--- a/src/GeekLearning.Email/IEmailSender.cs
+++ b/src/GeekLearning.Email/IEmailSender.cs
@@ -4,12 +4,12 @@
 
     public interface IEmailSender
     {
-        Task SendEmailAsync(string subject, string message, params IEmailAddress[] to);
+        Task SendEmailAsync(string subject, string message, IEnumerable<IEmailAddress> recipients, AttachmentCollection attachments=null);
 
-        Task SendEmailAsync(IEmailAddress from, string subject, string message, params IEmailAddress[] to);
+        Task SendEmailAsync(IEmailAddress from, string subject, string message, IEnumerable<IEmailAddress> recipients, AttachmentCollection attachments=null);
 
-        Task SendTemplatedEmailAsync<T>(string templateKey, T context, params IEmailAddress[] to);
+        Task SendTemplatedEmailAsync<T>(string templateKey, T context, IEnumerable<IEmailAddress> recipients, AttachmentCollection attachments=null);
 
-        Task SendTemplatedEmailAsync<T>(IEmailAddress from, string templateKey, T context, params IEmailAddress[] to);
+        Task SendTemplatedEmailAsync<T>(IEmailAddress from, string templateKey, T context, IEnumerable<IEmailAddress> recipients, AttachmentCollection attachments=null);
     }
 }

--- a/src/GeekLearning.Email/Internal/EmailAddress.cs
+++ b/src/GeekLearning.Email/Internal/EmailAddress.cs
@@ -6,14 +6,17 @@
         {
         }
 
-        public EmailAddress(string email, string displayName)
+        public EmailAddress(string email, string displayName, AddressTarget addressAs=AddressTarget.To)
         {
             this.Email = email;
             this.DisplayName = displayName;
+            this.AddressAs = addressAs;
         }
 
         public string Email { get; set; }
 
         public string DisplayName { get; set; }
+        
+        public AddressTarget AddressAs { get; set; }
     }
 }

--- a/tests/GeekLearning.Email.Integration.Test/SendTemplatedTest.cs
+++ b/tests/GeekLearning.Email.Integration.Test/SendTemplatedTest.cs
@@ -55,17 +55,14 @@
                 new SendGrid.SendGridEmailProviderType(),
             };
 
-            var emailSender = new Internal.EmailSender(
-                providerTypes,
-                options,
-                this.storeFixture.Services.GetRequiredService<IStorageFactory>(),
-                this.storeFixture.Services.GetRequiredService<ITemplateLoaderFactory>());
+            List<IEmailAddress> address = new List<IEmailAddress>() {
+                new Internal.EmailAddress(){
+                    DisplayName = "test user",
+                    Email = "no-reply@test.geeklearning.io",
+                    AddressAs = AddressTarget.To}
+            };
 
-            await emailSender.SendTemplatedEmailAsync("Notification1", new { }, new Internal.EmailAddress
-            {
-                DisplayName = "test user",
-                Email = "no-reply@test.geeklearning.io"
-            });
+            await emailSender.SendTemplatedEmailAsync("Notification1", new { }, address, null);
         }
     }
 }


### PR DESCRIPTION
Ok. This should be a little cleaner. My usage is mostly for the Smtp methods, but I added code to the InMemory and Sendgrid parts so that they would be still compatible with changes to the Smtp section.

Discussion:  breaking code changes? Also, I'm not sure email address validation inside these classes is best. I prefer validation in higher level code. Anyway, these libraries will really be improved by allowing attachments and targeting addresses to Bcc and Cc and so on. So, see what you think. 